### PR TITLE
Fix auth file for server use

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -3,8 +3,7 @@ import { redirect } from "next/navigation"
 import { auth } from "@/lib/auth"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Button } from "@/components/ui/button"
-import { signOut } from "@/lib/auth"
+import { SignOutButton } from "@/components/sign-out-button"
 
 export default async function ProfilePage() {
   const session = await auth()
@@ -62,14 +61,7 @@ export default async function ProfilePage() {
             </div>
 
             <div className="pt-4">
-              <form action={async () => {
-                "use server"
-                await signOut({ redirectTo: "/" })
-              }}>
-                <Button type="submit" variant="outline">
-                  Sign Out
-                </Button>
-              </form>
+              <SignOutButton />
             </div>
           </CardContent>
         </Card>

--- a/components/sign-out-button.tsx
+++ b/components/sign-out-button.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { signOut } from "next-auth/react"
+import { Button } from "@/components/ui/button"
+
+export function SignOutButton() {
+  return (
+    <Button onClick={() => signOut({ callbackUrl: "/" })} variant="outline">
+      Sign Out
+    </Button>
+  )
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,11 +1,9 @@
-
-import NextAuth from "next-auth"
+import NextAuth, { getServerSession, type NextAuthOptions } from "next-auth"
 import GoogleProvider from "next-auth/providers/google"
 import EmailProvider from "next-auth/providers/email"
 import { SupabaseAdapter } from "@next-auth/supabase-adapter"
-import type { NextAuthConfig } from "next-auth"
 
-export const authConfig: NextAuthConfig = {
+export const authConfig: NextAuthOptions = {
   providers: [
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID || "",
@@ -29,7 +27,6 @@ export const authConfig: NextAuthConfig = {
   }),
   callbacks: {
     async session({ session, user }) {
-      // Add user ID to the session
       if (session?.user) {
         session.user.id = user.id
       }
@@ -44,7 +41,12 @@ export const authConfig: NextAuthConfig = {
   },
 }
 
-const nextAuth = NextAuth(authConfig)
+export const handlers = {
+  GET: NextAuth(authConfig),
+  POST: NextAuth(authConfig),
+}
 
-export const { handlers, auth, signIn, signOut } = nextAuth
-export default nextAuth
+export async function auth() {
+  return await getServerSession(authConfig)
+}
+


### PR DESCRIPTION
## Summary
- remove client-only re-exports from `lib/auth.ts`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9b12fa88832f9d8077846511d1cb