### PR TITLE
Fix sign in page routing

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -9,7 +9,7 @@ export default async function ProfilePage() {
   const session = await auth()
 
   if (!session?.user) {
-    redirect("/api/auth/signin")
+    redirect("/signin")
   }
 
   const user = session.user

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -11,7 +11,7 @@ export default async function SettingsPage() {
   const session = await auth()
 
   if (!session?.user) {
-    redirect("/api/auth/signin")
+    redirect("/signin")
   }
 
   return (

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -1,6 +1,8 @@
 "use client"
 
-import { useState } from "react"
+export const dynamic = "force-dynamic"
+
+import { Suspense, useState } from "react"
 import { signIn } from "next-auth/react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
@@ -11,6 +13,14 @@ import { useToast } from "@/hooks/use-toast"
 import { Separator } from "@/components/ui/separator"
 
 export default function SignInPage() {
+  return (
+    <Suspense>
+      <SignInForm />
+    </Suspense>
+  )
+}
+
+function SignInForm() {
   const [isLoading, setIsLoading] = useState(false)
   const [email, setEmail] = useState("")
   const router = useRouter()
@@ -64,9 +74,9 @@ export default function SignInPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader>
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <Card className="w-full max-w-md">
+          <CardHeader>
           <CardTitle>Sign In</CardTitle>
           <CardDescription>Choose your preferred sign in method</CardDescription>
         </CardHeader>
@@ -127,4 +137,4 @@ export default function SignInPage() {
       </Card>
     </div>
   )
-} 
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -35,7 +35,7 @@ export const authConfig: NextAuthOptions = {
     },
   },
   pages: {
-    signIn: "/api/auth/signin",
+    signIn: "/signin",
     signOut: "/api/auth/signout",
     error: "/api/auth/error",
     verifyRequest: "/api/auth/verify-request",


### PR DESCRIPTION
## Summary
- move custom sign-in page out of API routes
- update NextAuth config and redirects to new `/signin` page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840f6c43fa8832f9b91e4911b2c258f