### PR TITLE
Remove duplicate sign-in API route

### DIFF
--- a/app/api/auth/signin/route.ts
+++ b/app/api/auth/signin/route.ts
@@ -1,3 +1,0 @@
-import { handlers } from "@/lib/auth"
-
-export const { GET, POST } = handlers 


### PR DESCRIPTION
## Summary
- delete custom `/api/auth/signin` endpoint so NextAuth catch-all route handles sign-in correctly

## Testing
- `npm run build`
- `curl -I http://localhost:3000/api/auth/signin` *(fails: NO_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_6840fafa3924832f94a9187186bcaa12